### PR TITLE
Add javac attributes to keep Android-compatibility

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -20,6 +20,7 @@
 	<target name="compile.stubs">
 		<mkdir dir="${stubs.dir}" />
 		<javac includeantruntime="false" srcdir="stubs" destdir="${stubs.dir}"
+                       source="1.6" target="1.6"
 			classpathref="classpath" />
 	</target>
 
@@ -27,6 +28,7 @@
 		description="compiles source code and puts classes in target/ directory">
 		<mkdir dir="${classes.dir}" />
 		<javac includeantruntime="false" srcdir="src" destdir="${classes.dir}"
+                       source="1.6" target="1.6"
 			debug="true" classpathref="classpath">
 			<classpath>
 				<path refid="classpath" />


### PR DESCRIPTION
When the attributes are absent, the jar files will be build against
whichever Java version the JDK is using, causing problems when using
JDK version greater than 6.

A typical problem caused by this:
http://stackoverflow.com/questions/7866723/dx-bad-class-file-magic-cafebabe-or-version-0033-0000-with-adk14
