### PR TITLE
fix lint error missing_translation

### DIFF
--- a/templates/migrations.xml.ftl
+++ b/templates/migrations.xml.ftl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <integer name="database_version">${sequence_number}</integer>
     <string name="database_name">${database_name}</string>
     <string name="package_name">${package}</string>


### PR DESCRIPTION
fixes #2

Problem: lint give errors when compiling in Android studio.

When droid-migrate generates the xml file it doesn't include the following 

```
<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
```
