### PR TITLE
Upgrade to current version after initial migration.

### DIFF
--- a/src/com/b50/migrations/MigrationsDatabaseHelper.java
+++ b/src/com/b50/migrations/MigrationsDatabaseHelper.java
@@ -8,11 +8,13 @@ import android.util.Log;
 public class MigrationsDatabaseHelper extends SQLiteOpenHelper {
 
 	protected Migrator migrator;
+	protected int intendedVersion;
 
 	public MigrationsDatabaseHelper(Context context, String dbName, SQLiteDatabase.CursorFactory factory,
 			int dbVersion, String packageName) {
 		super(context, dbName, null, dbVersion);
 		this.migrator = new Migrator(packageName);
+		this.intendedVersion = dbVersion;
 	}
 
 	public void onDowngrade(SQLiteDatabase db, int oldVersion, int newVersion) {
@@ -26,6 +28,9 @@ public class MigrationsDatabaseHelper extends SQLiteOpenHelper {
 	public void onCreate(SQLiteDatabase db) {
 		try {
 			migrator.initialMigration(db);
+			if (intendedVersion > 1) {
+				onUpgrade(db, 1, intendedVersion);
+			}
 		} catch (MigrationException e) {
 			Log.e("MigrationsDatabaseHelper", "exception with onCreate", e);
 		}


### PR DESCRIPTION
I have an app that I built with a database initially, then subsequently added droid-migrate to. Migrations work fine with this.

If I uninstall, clear all data, and reinstall, then the following happens:
- `onCreate` is run, and therefore the `DBVersion1` migration is executed successfully
- `onUpgrade` is not called, and so subsequent migrations don't take place

I've attached a small patch that migrates up _after_ creating the database initially.
