### PR TITLE
Allow missing migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,22 @@ $> droid-migrate generate down
 
 You will then need to provide the relevant SQL details in the newly generated `DBVersion<next_sequence>` class (just like you did for the initial class, dubbed `DBVersion1`).
 
+#Working with legacy apps
+
+If you are retrospectively applying migrations to a legacy application that already has a version number greater than 1, Droid Migrate can handle this.
+
+Let's say your version number is already ```5``` in your legacy application. Follow the steps above to add Droid Migrate to your project first of all. Then:
+
+1. Adjust ```database_version``` in ```res/values/migrations.xml``` and change it to ```5```
+2. Rename the ```DBVersion1.java``` class to ```DBVersion5.java```
+3. Adjust your instantiation of the `DatabaseHelper` class as follows:
+
+```
+SQLiteDatabase db = (new DatabaseHelper(this).setAlertOnMissingMigrations(false)).getWritableDatabase();
+```
+
+and your migrations will start from version 5 onwards.
+
 #How it works
 
 Droid Migrate's secret sauce can be found in three files: 

--- a/src/com/b50/migrations/MigrationsDatabaseHelper.java
+++ b/src/com/b50/migrations/MigrationsDatabaseHelper.java
@@ -17,6 +17,10 @@ public class MigrationsDatabaseHelper extends SQLiteOpenHelper {
 		this.intendedVersion = dbVersion;
 	}
 
+	public void setAlertOnMissingMigrations(boolean alertOnMissingMigrations) {
+		this.migrator.setAlertOnMissingMigrations(alertOnMissingMigrations);
+	}
+
 	public void onDowngrade(SQLiteDatabase db, int oldVersion, int newVersion) {
 		try {
 			migrator.downgrade(db, oldVersion, newVersion);

--- a/src/com/b50/migrations/Migrator.java
+++ b/src/com/b50/migrations/Migrator.java
@@ -4,9 +4,14 @@ import android.database.sqlite.SQLiteDatabase;
 
 public class Migrator {
 	private String packageName;
+	private boolean alertOnMissingMigrations = true;
 
 	public Migrator(String packageName) {
 		this.packageName = packageName;
+	}
+
+	public void setAlertOnMissingMigrations(boolean alertOnMissingMigrations) {
+		this.alertOnMissingMigrations = alertOnMissingMigrations;
 	}
 
 	public void initialMigration(SQLiteDatabase db) throws MigrationException {
@@ -17,7 +22,9 @@ public class Migrator {
 		} catch (IllegalAccessException e) {
 			throw new MigrationException(e);
 		} catch (ClassNotFoundException e) {
-			throw new MigrationException(e);
+			if (alertOnMissingMigrations) {
+				throw new MigrationException(e);
+			}
 		}
 	}
 
@@ -30,7 +37,9 @@ public class Migrator {
 			} catch (IllegalAccessException e) {
 				throw new MigrationException(e);
 			} catch (ClassNotFoundException e) {
-				throw new MigrationException(e);
+				if (alertOnMissingMigrations) {
+					throw new MigrationException(e);
+				}
 			}
 		}
 	}
@@ -44,7 +53,9 @@ public class Migrator {
 			} catch (IllegalAccessException e) {
 				throw new MigrationException(e);
 			} catch (ClassNotFoundException e) {
-				throw new MigrationException(e);
+				if (alertOnMissingMigrations) {
+					throw new MigrationException(e);
+				}
 			}
 		}
 	}

--- a/test/test/com/b50/migrations/MigratorTest.java
+++ b/test/test/com/b50/migrations/MigratorTest.java
@@ -36,7 +36,25 @@ public class MigratorTest {
 		Migrator migrator = new Migrator("test.com.b50.migrations.nopackage");
 		migrator.upgrade(mockedDB, 1, 2);		
 	}
-	
+
+	@Test
+	public void testDBCanIgnoreMissingInitialMigrationClass() throws Exception {
+		SQLiteDatabase mockedDB = mock(SQLiteDatabase.class);
+		Migrator migrator = new Migrator("test.com.b50.migrations");
+		migrator.setAlertOnMissingMigrations(false);
+		migrator.initialMigration(mockedDB);
+	}
+
+	@Test
+	public void testDBCanIgnoreMissingClasses() throws Exception {
+		SQLiteDatabase mockedDB = mock(SQLiteDatabase.class);
+		Migrator migrator = new Migrator("test.com.b50.migrations");
+		migrator.setAlertOnMissingMigrations(false);
+		migrator.upgrade(mockedDB, 1, 4); // Migration version 4 does not exist
+		verify(mockedDB, times(1)).execSQL("some additional sql stmts from #2");
+		verify(mockedDB, times(1)).execSQL("some additional sql stmts from #3");
+	}
+
 	@Test
 	public void testDBUpLogic() throws Exception {
 		SQLiteDatabase mockedDB = mock(SQLiteDatabase.class);


### PR DESCRIPTION
Useful when you are retrospectively applying migrations to a legacy app.

If your app already has a version number greater than 1, this allows you to start with a version number in your `migrations.xml` file which is equivalent to your existing version, and also to start with a higher-numbered `DBVersion` migration class.
